### PR TITLE
Added laceup shoes to the loadout menu

### DIFF
--- a/code/modules/client/preference/loadout/loadout_shoes.dm
+++ b/code/modules/client/preference/loadout/loadout_shoes.dm
@@ -44,3 +44,8 @@
 	display_name = "cowboy boots, pink"
 	cost = 1
 	path = /obj/item/clothing/shoes/cowboyboots/pink
+	
+/datum/gear/shoes/laceup
+	display_name = "laceup shoes"
+	cost = 1
+	path = /obj/item/clothing/shoes/laceup


### PR DESCRIPTION
Laceup shoes can now be bought for 1 loadout point. People who hate having sneakers at roundstart rejoice!

Here's hoping I did this right.

:cl: Jountax
rscadd: Can now add laceup shoes to your loadout.
/:cl: